### PR TITLE
code restructure based on ND REST workflow

### DIFF
--- a/jnpr/openclos/conf/cablingPlanTemplates/threeStage.txt
+++ b/jnpr/openclos/conf/cablingPlanTemplates/threeStage.txt
@@ -1,14 +1,12 @@
 {
 'cablingPlan': {
   'devices': [
-    {% for device in devices %}
-    {'id': '{{ device['id'] }}', 'name': '{{ device['name'] }}', 'role':'{{ device['role'] }}'}{% if not loop.last %},{% endif %}
-    {% endfor %} 
+    {% for device in devices %}    {'id': '{{ device['id'] }}', 'name': '{{ device['name'] }}', 'role':'{{ device['role'] }}'}{% if not loop.last %},
+    {% endif %}{% endfor %}
   ],
   'links': [
-    {% for link in links %}
-    { 'device1': '{{ link['device1'] }}', 'port1': '{{ link['port1'] }}', 'ip1':'{{ link['ip1'] }}', 'device2': '{{ link['device2'] }}', 'port2': '{{ link['port2'] }}', 'ip2':'{{ link['ip2'] }}'}{% if not loop.last %},{% endif %}
-    {% endfor %}
+    {% for link in links %}    { 'device1': '{{ link['device1'] }}', 'port1': '{{ link['port1'] }}', 'ip1':'{{ link['ip1'] }}', 'device2': '{{ link['device2'] }}', 'port2': '{{ link['port2'] }}', 'ip2':'{{ link['ip2'] }}'}{% if not loop.last %},
+    {% endif %}{% endfor %}
   ]
 }
 }

--- a/jnpr/openclos/conf/junosTemplates/protocolBgpLldp.txt
+++ b/jnpr/openclos/conf/junosTemplates/protocolBgpLldp.txt
@@ -14,8 +14,7 @@ protocols {
                 session-mode single-hop;
             }
             multipath multiple-as;
-            {% for neighbor in neighbors %}
-            neighbor {{neighbor['peer_ip']}} {
+            {% for neighbor in neighbors %}neighbor {{neighbor['peer_ip']}} {
                 peer-as {{neighbor['peer_asn']}};
             }
             {% endfor %}        

--- a/jnpr/openclos/conf/junosTemplates/routing_options_stanza.txt
+++ b/jnpr/openclos/conf/junosTemplates/routing_options_stanza.txt
@@ -1,12 +1,8 @@
 replace:
 routing-options {
-    {% if gateway %}
-    static {
-        {% for oobNetwork in oobNetworks %}
-        route {{oobNetwork}} next-hop {{gateway}};
-        {% endfor %}
-    }
-    {% endif %}        
+{% if gateway and oobNetworks|length %}    static {
+{% for oobNetwork in oobNetworks %}        route {{oobNetwork}} next-hop {{gateway}};
+{% endfor %}    }{% endif %}
     router-id {{routerId}};
     autonomous-system {{asn}};
     forwarding-table {

--- a/jnpr/openclos/dao.py
+++ b/jnpr/openclos/dao.py
@@ -39,6 +39,16 @@ class Dao:
             #self.Session.remove()
             pass
 
+    def deleteObjects(self, objects):
+        session = self.Session()
+        try:
+            for obj in objects:
+                session.delete(obj)
+            session.commit()
+        finally:
+            #self.Session.remove()
+            pass
+
     def updateObjects(self, objects):
         session = self.Session()
         try:
@@ -80,4 +90,3 @@ class Dao:
         finally:
             #self.Session.remove()
             pass
-

--- a/jnpr/openclos/tests/unit/test_model.py
+++ b/jnpr/openclos/tests/unit/test_model.py
@@ -126,12 +126,6 @@ class TestPod(TestOrm):
         error = ve.exception.message
         self.assertEqual(2, error.count(','), 'Number of bad Ip address format field is not correct')
 
-    def testValidateEnum(self):
-        with self.assertRaises(ValueError) :
-            Pod.validateEnum('Pod.TopologyTypeEnum', 'abcd', Pod.TopologyTypeEnum)
-        with self.assertRaises(ValueError) :
-            Pod.validateEnum('Pod.TopologyTypeEnum', ['abcd'], Pod.TopologyTypeEnum)
-
     def testConstructorPass(self):
         pod = {}
         pod['spineCount'] = '3'


### PR DESCRIPTION
ND REST workflow is like following:
1. When receiving HTTP POST (only once), call createPod providing pod name, a dictionary containing (could be partial) pod information, a dictionary containing inventory (optional). createPod returns the pod object created. ValueError thrown if pod can't be created.
2. When receiving HTTP PUT (one or more times), call updatePod providing pod.id, a dictionary containing (could be partial) pod information, a dictionary containing inventory (optional). updatePod returns the same pod object. ValueError thrown if pod can't be found or updated.
3. When receiving HTTP POST about creating cabling plan, call createCablingPlan provide pod.id. createCablingPlan returns True if no error encounted. ValueError thrown if failed.
4. When receiving HTTP POST about creating device config, call createDeviceConfig provide pod.id. createDeviceConfig returns True if no error encounted. ValueError thrown if failed.

Also minor fix to remove empty lines in device config.
