### PR TITLE
add trap receiver

### DIFF
--- a/jnpr/openclos/conf/openclos.yaml
+++ b/jnpr/openclos/conf/openclos.yaml
@@ -39,6 +39,7 @@ logLevel :
     rest : INFO
     writer : INFO
     devicePlugin : INFO
+    trapd : INFO
 
 
 # debug SQL and ORM
@@ -102,7 +103,7 @@ snmpTrap :
         target : 1.2.3.4
     openclos_trap_group :
         port : 20162
-        target : 1.2.3.4
+        target : 0.0.0.0
 
 
 # various scripts

--- a/jnpr/openclos/tests/unit/test_trapd.py
+++ b/jnpr/openclos/tests/unit/test_trapd.py
@@ -1,0 +1,57 @@
+'''
+Created on Nov. 6, 2014
+
+@author: yunli
+'''
+import unittest
+import os
+import shutil
+from time import sleep
+
+from jnpr.openclos.trapd import TrapReceiver
+
+class TestTrapReceiver(unittest.TestCase):
+
+    def testInit(self):
+        self.conf = {}
+        self.conf['snmpTrap'] = {}
+        self.conf['snmpTrap']['openclos_trap_group'] = {}
+        self.conf['snmpTrap']['openclos_trap_group']['target'] = "1.1.1.1"
+        self.conf['snmpTrap']['openclos_trap_group']['port'] = 20163
+        trapReceiver = TrapReceiver(self.conf)
+        self.assertEqual('1.1.1.1', trapReceiver.target)
+        self.assertEqual(20163, trapReceiver.port)
+    
+    def testInitDefaultValue(self):
+        self.conf = {}
+        self.conf['snmpTrap'] = {}
+        trapReceiver = TrapReceiver(self.conf)
+        self.assertEqual('0.0.0.0', trapReceiver.target)
+        self.assertEqual(20162, trapReceiver.port)
+        
+    def isPortOpen(self, port):
+        cmd = "netstat -an | grep " + str(port)
+        result = os.popen(cmd).read()
+        if result.find(str(port)) != -1:
+            return True
+        else:
+            return False
+           
+    def testStart(self):
+        self.conf = {}
+        self.conf['snmpTrap'] = {}
+        self.conf['snmpTrap']['openclos_trap_group'] = {}
+        self.conf['snmpTrap']['openclos_trap_group']['target'] = "0.0.0.0"
+        self.conf['snmpTrap']['openclos_trap_group']['port'] = 20162
+        trapReceiver = TrapReceiver(self.conf)
+        trapReceiver.start()
+        sleep(2)
+        self.assertEqual(True, self.isPortOpen(20162))
+        trapReceiver.stop()
+        sleep(2)
+        self.assertEqual(False, self.isPortOpen(20162))
+        
+        
+if __name__ == "__main__":
+    #import sys;sys.argv = ['', 'Test.testName']
+    unittest.main()

--- a/jnpr/openclos/trapd.py
+++ b/jnpr/openclos/trapd.py
@@ -1,0 +1,144 @@
+'''
+Created on Nov. 06, 2014
+
+@author: yunli
+'''
+
+from pysnmp.carrier.asynsock.dispatch import AsynsockDispatcher
+from pysnmp.carrier.asynsock.dgram import udp
+from pyasn1.codec.ber import decoder
+from pysnmp.proto import api
+from threading import Thread
+import logging
+import util
+import signal
+import sys
+
+moduleName = 'trapd'
+logging.basicConfig()
+logger = logging.getLogger(moduleName)
+logger.setLevel(logging.DEBUG)
+
+DEFAULT_HOST = "0.0.0.0"
+DEFAULT_PORT = 20162
+
+trapReceiver = None
+
+def onTrap(transportDispatcher, transportDomain, transportAddress, wholeMsg):
+    while wholeMsg:
+        msgVer = int(api.decodeMessageVersion(wholeMsg))
+        if msgVer in api.protoModules:
+            pMod = api.protoModules[msgVer]
+        else:
+            logger.debug('Unsupported SNMP version %s' % msgVer)
+            return
+        reqMsg, wholeMsg = decoder.decode(
+            wholeMsg, asn1Spec=pMod.Message(),
+            )
+        logger.debug('Notification message from %s:%s: ' % (
+            transportDomain, transportAddress
+            )
+        )
+        reqPDU = pMod.apiMessage.getPDU(reqMsg)
+        if reqPDU.isSameTypeWith(pMod.TrapPDU()):
+            if msgVer == api.protoVersion1:
+                logger.debug('Enterprise: %s' % (
+                    pMod.apiTrapPDU.getEnterprise(reqPDU).prettyPrint()
+                    )
+                )
+                logger.debug('Agent Address: %s' % (
+                    pMod.apiTrapPDU.getAgentAddr(reqPDU).prettyPrint()
+                    )
+                )
+                logger.debug('Generic Trap: %s' % (
+                    pMod.apiTrapPDU.getGenericTrap(reqPDU).prettyPrint()
+                    )
+                )
+                logger.debug('Specific Trap: %s' % (
+                    pMod.apiTrapPDU.getSpecificTrap(reqPDU).prettyPrint()
+                    )
+                )
+                logger.debug('Uptime: %s' % (
+                    pMod.apiTrapPDU.getTimeStamp(reqPDU).prettyPrint()
+                    )
+                )
+                varBinds = pMod.apiTrapPDU.getVarBindList(reqPDU)
+            else:
+                varBinds = pMod.apiPDU.getVarBindList(reqPDU)
+            logger.debug('Var-binds:')
+            for oid, val in varBinds:
+                logger.debug('%s = %s' % (oid.prettyPrint(), val.prettyPrint()))
+    return wholeMsg
+
+class TrapReceiver():
+    def __init__(self, conf = {}):
+        if conf is None or any(conf) == False:
+            self.conf = util.loadConfig()
+        else:
+            self.conf = conf
+        if 'logLevel' in self.conf:
+            logger.setLevel(logging.getLevelName(self.conf['logLevel'][moduleName])) 
+
+        # default value
+        self.target = DEFAULT_HOST
+        self.port = DEFAULT_PORT
+        
+        # validate required parameter
+        if 'snmpTrap' in self.conf and 'openclos_trap_group' in self.conf['snmpTrap'] and 'target' in self.conf['snmpTrap']['openclos_trap_group']:
+            self.target = self.conf['snmpTrap']['openclos_trap_group']['target']
+        else:
+            logger.info("snmpTrap:openclos_trap_group:target is missing from configuration. using %s" % (self.target))                
+
+        if 'snmpTrap' in self.conf and 'openclos_trap_group' in self.conf['snmpTrap'] and 'port' in self.conf['snmpTrap']['openclos_trap_group']:
+            self.port = int(self.conf['snmpTrap']['openclos_trap_group']['port'])
+        else:
+            logger.info("snmpTrap:openclos_trap_group:port is missing from configuration. using %d" % (self.port))                
+       
+    def threadFunction(self):
+        self.transportDispatcher = AsynsockDispatcher()
+
+        self.transportDispatcher.registerRecvCbFun(onTrap)
+        
+        # UDP/IPv4
+        self.transportDispatcher.registerTransport(
+            udp.domainName, udp.UdpSocketTransport().openServerMode((self.target, self.port))
+        )
+
+        self.transportDispatcher.jobStarted(1)
+
+        try:
+            # Dispatcher will never finish as job#1 never reaches zero
+            self.transportDispatcher.runDispatcher()
+        except:
+            self.transportDispatcher.closeDispatcher()
+            raise
+        else:
+            self.transportDispatcher.closeDispatcher()
+
+    def start(self):
+        logger.info("Starting trap receiver...")
+        self.thread = Thread(target=self.threadFunction, args=())
+        self.thread.start()
+        logger.info("Trap receiver started on %s:%d" % (self.target, self.port))
+
+    def stop(self):
+        logger.info("Stopping trap receiver...")
+        self.transportDispatcher.jobFinished(1)  
+        self.thread.join()
+        logger.info("Trap receiver stopped")
+
+        
+def trap_receiver_signal_handler(signal, frame):
+    logger.debug("received signal %d" % signal)
+    trapReceiver.stop()
+    sys.exit(0)
+        
+if __name__ == '__main__':
+    signal.signal(signal.SIGINT, trap_receiver_signal_handler)
+    signal.signal(signal.SIGTERM, trap_receiver_signal_handler)
+    trapReceiver = TrapReceiver()
+    trapReceiver.start()
+    # Note we have to do this in order for signal to be properly caught by main thread
+    # We need to do the similar thing when we integrate this into sampleApplication.py
+    while True:
+        signal.pause()

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
     # project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/technical.html#install-requires-vs-requirements-files
-    install_requires=['netaddr', 'sqlalchemy >= 0.9.6', 'pyyaml', 'nose', 'coverage', 'jinja2', 'flexmock', 'pydot', 'bottle', 'webtest', 'junos-eznc', 'futures' ],
+    install_requires=['netaddr', 'sqlalchemy >= 0.9.6', 'pyyaml', 'nose', 'coverage', 'jinja2', 'flexmock', 'pydot', 'bottle', 'webtest', 'junos-eznc', 'futures', 'pysnmp' ],
 
     # If there are data files included in your packages that need to be
     # installed, specify them here.  If using Python 2.6 or less, then these


### PR DESCRIPTION
I added trap receiver. 
1. it can run as standalone (python trapd.py) as a simple test app.
2. it is also integrated into sampleApplication.py
3. I added clean stop for sampleApplication as a whole. So now you can send SIGINT SIGTERM (either by ctrl-c or progmatically) to terminate it. But I left out the clean stop for rest server because I don't know.
4. right now the trap receiver just prints out the trap. waiting to hook up with 2 stage code.
