### PR TITLE
ND integration issues

### DIFF
--- a/jnpr/openclos/conf/closTemplate.yaml
+++ b/jnpr/openclos/conf/closTemplate.yaml
@@ -31,9 +31,9 @@ pods:
         leafUplinkcountMustBeUp : 3 
         
         hostOrVmCountPerLeaf : 254
-        interConnectPrefix : 192.168.0.0
-        vlanPrefix : 172.16.0.0
-        loopbackPrefix : 10.10.0.0
+        interConnectPrefix : 192.168.0.0/24
+        vlanPrefix : 172.16.0.0/22
+        loopbackPrefix : 10.10.0.0/24
         managementPrefix : 172.32.30.101/24
         spineAS : 100
         leafAS : 200
@@ -72,9 +72,9 @@ pods:
         # leafUplinkcountMustBeUp : 2 
 
         hostOrVmCountPerLeaf : 254
-        interConnectPrefix : 192.169.0.0
-        vlanPrefix : 172.17.0.0
-        loopbackPrefix : 10.11.0.0
+        interConnectPrefix : 192.169.0.0/24
+        vlanPrefix : 172.17.0.0/22
+        loopbackPrefix : 10.11.0.0/24
         managementPrefix : 192.168.48.216/24
         spineAS : 300
         leafAS : 400

--- a/jnpr/openclos/conf/junosTemplates/baseTemplate.txt
+++ b/jnpr/openclos/conf/junosTemplates/baseTemplate.txt
@@ -1,5 +1,5 @@
 system {
-    host-name "{{hostName}}";
+    {% if hostName is defined %}host-name "{{hostName}}";{% endif %}
     time-zone America/Los_Angeles;
     root-authentication {
         encrypted-password "{{hashedPassword}}"; ## SECRET-DATA

--- a/jnpr/openclos/conf/junosTemplates/routingOptionsStatic.txt
+++ b/jnpr/openclos/conf/junosTemplates/routingOptionsStatic.txt
@@ -1,6 +1,7 @@
-routing-options {
+{% if oob['gateway'] and oob['networks']|length %}routing-options {
     replace:
-{% if oob['gateway'] and oob['networks']|length %}    static {
+    static {
 {% for oobNetwork in oob['networks'] %}        route {{oobNetwork}} next-hop {{oob['gateway']}};
-{% endfor %}    }{% endif %}
+{% endfor %}    }
 }
+{% endif %}

--- a/jnpr/openclos/devicePlugin.py
+++ b/jnpr/openclos/devicePlugin.py
@@ -128,7 +128,7 @@ class L2DataCollector(DeviceDataCollectorNetconf):
     
     def startCollectAndProcessLldp(self):
         if (self.collectionInProgressCache.isDeviceInProgress(self.device.id)):
-            logger.trace('Data collection is in progress for %s', (self.deviceLogStr))
+            logger.debug('Data collection is in progress for %s', (self.deviceLogStr))
             return
         
         if (self.collectionInProgressCache.checkAndAddDevice(self.device.id)):
@@ -151,7 +151,7 @@ class L2DataCollector(DeviceDataCollectorNetconf):
                 logger.debug('Ended CollectAndProcessLldp for %s' % (self.deviceLogStr))
                 
         else:
-            logger.trace('Data collection is in progress for %s', (self.deviceLogStr))
+            logger.debug('Data collection is in progress for %s', (self.deviceLogStr))
             
     def validateDeviceL2Status(self, goodBadCount):
         if (goodBadCount['goodUplinkCount'] < self.device.pod.leafUplinkcountMustBeUp):
@@ -282,7 +282,7 @@ class TwoStageConfigurator(L2DataCollector):
     def collectLldpAndMatchDevice(self):
 
         if (self.configurationInProgressCache.isDeviceInProgress(self.device.id)):
-            logger.trace('Two stage configuration is in progress for %s, skipping', (self.deviceLogStr))
+            logger.debug('Two stage configuration is in progress for %s, skipping', (self.deviceLogStr))
             return
         
         if (self.configurationInProgressCache.checkAndAddDevice(self.device.id)):
@@ -317,7 +317,7 @@ class TwoStageConfigurator(L2DataCollector):
                 self.configurationInProgressCache.doneDevice(self.deviceId)
                 logger.debug('Ended two stage configuration for %s' % (self.deviceLogStr))
         else:
-            logger.trace('Two stage configuration is in progress for %s, skipping', (self.deviceLogStr))
+            logger.debug('Two stage configuration is in progress for %s, skipping', (self.deviceLogStr))
 
     def filterRemotePortIfdInDb(self,lldpData, deviceFamily):
         ''' filter only remote ports that are  IFD configured in the DB '''
@@ -371,7 +371,8 @@ class TwoStageConfigurator(L2DataCollector):
             return
 
         device = self.dao.getObjectById(Device, keyForMaxCount)
-        device.managementIp = self.deviceIp
+        mgmtNetwork = IPNetwork(device.pod.managementPrefix)
+        device.managementIp = self.deviceIp + '/' + str(mgmtNetwork.prefixlen)
         self.dao.updateObjects([device])
         
         # Is BEST match good enough match

--- a/jnpr/openclos/model.py
+++ b/jnpr/openclos/model.py
@@ -120,14 +120,14 @@ class Pod(ManagedElement, Base):
         if 'topologyType' in podDict:
             self.topologyType = podDict.get('topologyType')
         if 'outOfBandAddressList' in podDict:
-            addressList = []
             outOfBandAddressList = podDict.get('outOfBandAddressList')
-            if isinstance(outOfBandAddressList, list) == True:
-                addressList = outOfBandAddressList
-            else:
-                addressList.append(outOfBandAddressList)
-            self.outOfBandAddressList = ','.join(addressList)
-            podDict.pop('outOfBandAddressList')
+            if outOfBandAddressList is not None and len(outOfBandAddressList) > 0:
+                addressList = []
+                if isinstance(outOfBandAddressList, list) == True:
+                    addressList = outOfBandAddressList
+                else:
+                    addressList.append(outOfBandAddressList)
+                self.outOfBandAddressList = ','.join(addressList)
         if 'outOfBandGateway' in podDict:
             self.outOfBandGateway = podDict.get('outOfBandGateway')
         if 'spineJunosImage' in podDict:

--- a/jnpr/openclos/report.py
+++ b/jnpr/openclos/report.py
@@ -123,7 +123,8 @@ class L2Report(Report):
             logger.error('No pod found for podId: %s' % (podId))
             raise ValueError('No pod found for podId: %s' % (podId)) 
         
-        if not cachedData:
+        if cachedData == False:
+            logger.info('Generating L2Report from real data')
             futureList = []
             for device in pod.devices:
                 if device.role == 'leaf':

--- a/jnpr/openclos/rest.py
+++ b/jnpr/openclos/rest.py
@@ -574,9 +574,13 @@ class RestServer():
 
     def getL2Report(self, ipFabricId):
         try:
-            cached = bottle.request.query.get('cached', True)
+            cached = bottle.request.query.get('cached', '1')
+            if cached == '1':
+                cachedData = True
+            else:
+                cachedData = False
             bottle.response.headers['Content-Type'] = 'application/json'
-            return self.l2Report.generateReport(ipFabricId, cached)
+            return self.l2Report.generateReport(ipFabricId, cachedData)
 
         except ValueError:
             raise bottle.HTTPError(404, "Fabric with id: %s not found" % (ipFabricId))

--- a/jnpr/openclos/tests/unit/test_l3Clos.py
+++ b/jnpr/openclos/tests/unit/test_l3Clos.py
@@ -48,7 +48,7 @@ class TestL3Clos(unittest.TestCase):
         shutil.rmtree(self.conf['outputDir'], ignore_errors=True)
 
     def createPod(self, l3ClosMediation):
-        podDict = {"devicePassword": "Embe1mpls", "hostOrVmCountPerLeaf": 254, "leafDeviceType": "qfx5100-48s-6q", "spineAS": 100, "spineDeviceType": "qfx5100-24q-2p", "leafCount": 2, "interConnectPrefix": "192.168.0.0", "spineCount": 2, "vlanPrefix": "172.16.0.0", "topologyType": "threeStage", "loopbackPrefix": "10.0.0.0", "leafAS": 200, "managementPrefix": "172.32.30.101/24", "inventory" : "inventoryUnitTest.json"}
+        podDict = {"devicePassword": "Embe1mpls", "hostOrVmCountPerLeaf": 254, "leafDeviceType": "qfx5100-48s-6q", "spineAS": 100, "spineDeviceType": "qfx5100-24q-2p", "leafCount": 2, "interConnectPrefix": "192.168.0.0/24", "spineCount": 2, "vlanPrefix": "172.16.0.0/22", "topologyType": "threeStage", "loopbackPrefix": "10.0.0.0/24", "leafAS": 200, "managementPrefix": "172.32.30.101/24", "inventory" : "inventoryUnitTest.json"}
         pod = l3ClosMediation.createPod('pod1', podDict)
         return (pod, podDict)
 

--- a/jnpr/openclos/tests/unit/test_report.py
+++ b/jnpr/openclos/tests/unit/test_report.py
@@ -4,6 +4,7 @@ Created on Sep 9, 2014
 @author: moloyc
 '''
 import unittest
+import os
 
 from jnpr.openclos.report import ResourceAllocationReport, L2Report
 
@@ -13,7 +14,29 @@ class Test(unittest.TestCase):
     def setUp(self):
         '''Creates with in-memory DB'''
         self.conf = {}
+        self.conf['outputDir'] = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'out')
         self.conf['dbUrl'] = 'sqlite:///'
+        self.conf['writeConfigInFile'] = 'false'
+        self.conf['logLevel'] = { 
+                'fabric' : 'INFO',
+                'reporting' : 'INFO',
+                'ztp' : 'INFO',
+                'rest' : 'INFO',
+                'writer' : 'INFO',
+                'devicePlugin' : 'INFO',
+                'trapd' : 'INFO',
+                'dao' : 'INFO'
+        }
+        self.conf['DOT'] = {'ranksep' : '5 equally', 'colors': ['red', 'green', 'blue']}
+        self.conf['deviceFamily'] = {
+            "qfx5100-24q-2p": {
+                "ports": 'et-0/0/[0-23]'
+            },
+            "qfx5100-48s-6q": {
+                "uplinkPorts": 'et-0/0/[48-53]', 
+                "downlinkPorts": 'xe-0/0/[0-47]'
+            }
+        }
         self.report = ResourceAllocationReport(self.conf)
         self.session = self.report.dao.Session()
 
@@ -24,15 +47,21 @@ class Test(unittest.TestCase):
         from test_model import createPod
         pod = createPod("test", self.session)
         pod.allocatedInterConnectBlock = '1.2.3.4/24'
-        pod.interConnectPrefix = '1.2.0.0'
+        pod.interConnectPrefix = '1.2.0.0/24'
         
         interconnectAllocation = self.report.getInterconnectAllocation("test")
-        self.assertEqual('1.2.0.0', interconnectAllocation['block'])
+        self.assertEqual('1.2.0.0/24', interconnectAllocation['block'])
         self.assertEqual('1.2.3.4/24', interconnectAllocation['allocated'])
 
     def testGetInterconnectAllocationNoPod(self):
         interconnectAllocation = self.report.getInterconnectAllocation("test")
         self.assertEqual({}, interconnectAllocation)
+        
+    def testGenerateReport(self):
+        l2Report = L2Report()
+        from test_model import createPod
+        pod = createPod("test", l2Report.dao.Session())
+        l2Report.generateReport(pod.id, True, False)
 
 if __name__ == "__main__":
     #import sys;sys.argv = ['', 'Test.testName']

--- a/jnpr/openclos/trapd.py
+++ b/jnpr/openclos/trapd.py
@@ -40,8 +40,8 @@ def onTrap(transportDispatcher, transportDomain, transportAddress, wholeMsg):
             reqMsg, wholeMsg = decoder.decode(
                 wholeMsg, asn1Spec=pMod.Message(),
                 )
-            logger.info('Notification message from %s: ' % (
-                transportAddress
+            logger.info('Notification message from %s:%s ' % (
+                transportAddress[0], transportAddress[1]
                 )
             )
             reqPDU = pMod.apiMessage.getPDU(reqMsg)


### PR DESCRIPTION
1.     Leaf management IP is updated incorrectly during 2stage config. It should include netmask which we obtain by parsing managementPrefix given by ND.
2.  Empty host-name line should be removed from leafGenericConfig. This causes failure to load generic leaf config.
3.  In case of ND is in the same subnet, outOfBandNetworkList and outOfBandGateway should be absent in http request from ND. OpenClos needs to handle that.
4.  Management IP allocation order is leaf first in latest code drop. Correct order is spine first.
5.  Non-cached L2 report is not invoked (even with http header cached:False).
6.  2 minor incorrect log messages in trapd.py.
7.  Accept netmask of loopback/interconnect/vlan IP blocks from ND (include some validation)
