### PR TITLE
PR 1051924 [Confidential] - [CLoS setup] When we give interconnect, vlan...

### DIFF
--- a/jnpr/openclos/conf/closTemplate.yaml
+++ b/jnpr/openclos/conf/closTemplate.yaml
@@ -43,6 +43,16 @@ pods:
         interConnectPrefix : 192.168.0.0/24
         vlanPrefix : 172.16.0.0/21
         loopbackPrefix : 10.10.0.0/24
+        # either managementPrefix or (managementStartingIP, managementMask) is mandatory. Here is how it works:
+        # case 1: managementPrefix : 1.2.3.7/24
+        #         from cidr notation of managementPrefix we know available block is [1.2.3.0 - 1.2.3.255]
+        #         from ip portion of managementPrefix we know starting ip is 1.2.3.7
+        #         so the effective range is [1.2.3.7 - 1.2.3.7+spineCount+leafCount]
+        # case 2: managementStartingIP : 1.2.3.7
+        #         managementMask : 24
+        #         from cidr notation of 'managementStartingIP/managementMask' we know available block is [1.2.3.0 - 1.2.3.255]
+        #         from managementStartingIP we know starting ip is 1.2.3.7
+        #         so the effective range is [1.2.3.7 - 1.2.3.7+spineCount+leafCount]
         managementPrefix : 172.32.30.101/24
         spineAS : 100
         leafAS : 200
@@ -88,6 +98,16 @@ pods:
         interConnectPrefix : 192.169.0.0/24
         vlanPrefix : 172.17.0.0/22
         loopbackPrefix : 10.11.0.0/24
+        # either managementPrefix or (managementStartingIP, managementMask) is mandatory. Here is how it works:
+        # case 1: managementPrefix : 1.2.3.7/24
+        #         from cidr notation of managementPrefix we know available block is [1.2.3.0 - 1.2.3.255]
+        #         from ip portion of managementPrefix we know starting ip is 1.2.3.7
+        #         so the effective range is [1.2.3.7 - 1.2.3.7+spineCount+leafCount]
+        # case 2: managementStartingIP : 1.2.3.7
+        #         managementMask : 24
+        #         from cidr notation of 'managementStartingIP/managementMask' we know available block is [1.2.3.0 - 1.2.3.255]
+        #         from managementStartingIP we know starting ip is 1.2.3.7
+        #         so the effective range is [1.2.3.7 - 1.2.3.7+spineCount+leafCount]
         managementPrefix : 192.168.48.216/24
         spineAS : 300
         leafAS : 400

--- a/jnpr/openclos/tests/unit/test_util.py
+++ b/jnpr/openclos/tests/unit/test_util.py
@@ -83,11 +83,11 @@ class TestFunctions(unittest.TestCase):
             
     def testGetMgmtIps(self):
         mgmtIpList = ["1.2.3.1/24", "1.2.3.2/24", "1.2.3.3/24", "1.2.3.4/24", "1.2.3.5/24", "1.2.3.6/24"] 
-        mgmtIps = getMgmtIps("1.2.3.1/24", 6)
+        mgmtIps = getMgmtIps("1.2.3.1/24", None, None, 6)
         self.assertEqual(mgmtIpList, mgmtIps)
 
         mgmtIpList = ["192.168.48.216/25", "192.168.48.217/25", "192.168.48.218/25", "192.168.48.219/25", "192.168.48.220/25"] 
-        mgmtIps = getMgmtIps("192.168.48.216/25", 5)
+        mgmtIps = getMgmtIps("192.168.48.216/25", None, None, 5)
         self.assertEqual(mgmtIpList, mgmtIps)
 
     def testIsIntegratedWithNd(self):

--- a/jnpr/openclos/util.py
+++ b/jnpr/openclos/util.py
@@ -187,7 +187,7 @@ def backupDatabase(conf):
                 backupDbFileName = dbFileName + '.' + timestamp
                 shutil.copyfile(dbFileName, backupDbFileName)
 
-def getMgmtIps(prefix, count):
+def getMgmtIps(prefix, startingIP, mask, count):
     '''
     returns list of management IP for given number of devices
     
@@ -196,13 +196,20 @@ def getMgmtIps(prefix, count):
     count -- number of devices
     '''
     mgmtIps = []
-    ipNetwork = IPNetwork(prefix)
-    ipNetworkList = list(ipNetwork)
-    start = ipNetworkList.index(ipNetwork.ip)
-    end = start + count
-    ipList = ipNetworkList[start:end]
-    for ip in ipList:
-        mgmtIps.append(str(ip) + '/' + str(ipNetwork.prefixlen))
+    cidr = None
+    if startingIP is not None and mask is not None:
+        cidr = startingIP + '/' + str(mask)
+    else:
+        cidr = prefix
+        
+    if cidr is not None:
+        ipNetwork = IPNetwork(cidr)
+        ipNetworkList = list(ipNetwork)
+        start = ipNetworkList.index(ipNetwork.ip)
+        end = start + count
+        ipList = ipNetworkList[start:end]
+        for ip in ipList:
+            mgmtIps.append(str(ip) + '/' + str(ipNetwork.prefixlen))
 
     return mgmtIps
 


### PR DESCRIPTION
... and loopback ip as 10.0.0.10/24 start ip is taken from 11.0.0.8 instead of 10.0.0.0

fixed cidr notation calculation
also introduced managementStartingIP and managementMask:

case 1: managementPrefix : 1.2.3.7/24
        from cidr notation of managementPrefix we know available block is [1.2.3.0 - 1.2.3.255]
        from ip portion of managementPrefix we know starting ip is 1.2.3.7
        so the effective range is [1.2.3.7 - 1.2.3.7+spineCount+leafCount]
case 2: managementStartingIP : 1.2.3.7
        managementMask : 24
        from cidr notation of 'managementStartingIP/managementMask' we know available block is [1.2.3.0 - 1.2.3.255]
        from managementStartingIP we know starting ip is 1.2.3.7
        so the effective range is [1.2.3.7 - 1.2.3.7+spineCount+leafCount]