### PR TITLE
1053171	[OpenClos Tracker] Interface names are wrong in cabling plan for...

### DIFF
--- a/jnpr/openclos/conf/openclos.yaml
+++ b/jnpr/openclos/conf/openclos.yaml
@@ -58,18 +58,18 @@ deviceFamily :
     qfx5100-24q-2p :
         uplinkPorts : 
         downlinkPorts : 
-        ports : 'et-0/0/[0-31]'
+        ports : ['et-0/0/[0-23]', 'et-0/1/[0-3]', 'et-0/2/[0-3]']
     qfx5100-48s-6q :
         uplinkPorts : 'et-0/0/[48-53]'
-        downlinkPorts : 'xe-0/0/[0-47]'
+        downlinkPorts : ['xe-0/0/[0-47]', 'ge-0/0/[0-47]']
         ports :
     qfx5100-48t-6q :
         uplinkPorts : 'et-0/0/[48-53]' 
-        downlinkPorts : 'xe-0/0/[0-47]'
+        downlinkPorts : ['xe-0/0/[0-47]', 'ge-0/0/[0-47]']
         ports :  
     qfx5100-96s-8q :
         uplinkPorts : 'et-0/0/[96-103]'
-        downlinkPorts : 'xe-0/0/[0-95]'
+        downlinkPorts : ['xe-0/0/[0-47]', 'ge-0/0/[0-47]']
         ports :
     ex4300-24p :
         uplinkPorts : 'et-0/1/[0-3]'
@@ -80,7 +80,7 @@ deviceFamily :
         downlinkPorts : 'ge-0/0/[0-23]'
         ports :
     ex4300-32f :
-        uplinkPorts : 'et-0/1/[0-3]'
+        uplinkPorts : ['et-0/1/[0-1]', 'et-0/2/[0-1]']
         downlinkPorts : 'ge-0/0/[0-31]'
         ports :
     ex4300-48p :

--- a/jnpr/openclos/tests/unit/test_util.py
+++ b/jnpr/openclos/tests/unit/test_util.py
@@ -73,6 +73,14 @@ class TestFunctions(unittest.TestCase):
         self.assertEqual(10, len(portNames))
         self.assertEqual('xe-0/0/1', portNames[0])
         self.assertEqual('xe-0/0/10', portNames[9])        
+        
+    def testExpandPortNameList(self):
+        portNames = expandPortName(['xe-0/0/[1-10]', 'et-0/0/[0-3]'])
+        self.assertEqual(14, len(portNames))
+        self.assertEqual('xe-0/0/1', portNames[0])
+        self.assertEqual('xe-0/0/10', portNames[9])        
+        self.assertEqual('et-0/0/0', portNames[10])        
+        self.assertEqual('et-0/0/3', portNames[13])        
 
     def testFixSqlliteDbUrlForRelativePath(self):
         dbUrl = fixSqlliteDbUrlForRelativePath('sqlite:////absolute-path/sqllite3.db')

--- a/jnpr/openclos/util.py
+++ b/jnpr/openclos/util.py
@@ -150,24 +150,32 @@ def expandPortName(portName):
     Currently it does not expands all junos regex, only few limited 
 
     Keyword arguments:
-    portName -- port name in junos regular expression, example: xe-0/0/[0-10]
+    portName -- port name in junos regular expression. 
+                it could be a single string in format: xe-0/0/[0-10]
+                or it could be a list of strings where each string is in format: ['xe-0/0/[0-10]', 'et-0/0/[0-3]']
     '''
-    if portName is None or portName == '':
+    if not portName or portName == '':
         return []
     
-    error = "Port name regular expression is not formatted properly: %s, example: xe-0/0/[0-10]" % (portName)
-    match = re.match(r"([a-z]+-\d\/\d\/\[)(\d{1,3})-(\d{1,3})(\])", portName)
-    if match is None:
-        raise ValueError(error)
+    portList = []
+    if isinstance(portName, list) == True:
+        portList = portName
+    else:
+        portList.append(portName)
     
     portNames = []
-    preRegx = match.group(1)    # group index starts with 1, NOT 0
-    postRegx = match.group(4)
-    startNum = int(match.group(2))
-    endNum = int(match.group(3))
-    
-    for id in range(startNum, endNum + 1):
-        portNames.append(preRegx[:-1] + str(id) + postRegx[1:])
+    for port in portList:
+        match = re.match(r"([a-z]+-\d\/\d\/\[)(\d{1,3})-(\d{1,3})(\])", port)
+        if match is None:
+            raise ValueError("Port name regular expression is not formatted properly: %s, example: xe-0/0/[0-10]" % (port))
+        
+        preRegx = match.group(1)    # group index starts with 1, NOT 0
+        postRegx = match.group(4)
+        startNum = int(match.group(2))
+        endNum = int(match.group(3))
+        
+        for id in range(startNum, endNum + 1):
+            portNames.append(preRegx[:-1] + str(id) + postRegx[1:])
         
     return portNames
 


### PR DESCRIPTION
... EX4300-32F when we have more than 2 spines and for QFX5100-24Q when we have more than 24 leaves

1053885	GE interfaces are not configured in QFX5100-48s and QFX5100-96S leavesi
1053886	[openclos tracker 1053885] GE interfaces are not configured in QFX5100-48s and QFX5100-96S leaves