### PR TITLE
Update l3Clos.py

### DIFF
--- a/jnpr/openclos/l3Clos.py
+++ b/jnpr/openclos/l3Clos.py
@@ -305,10 +305,9 @@ class L3ClosMediation():
             configWriter.write(device, config)
             
     def createBaseConfig(self, device):
-        with open(os.path.join(os.path.dirname(os.path.abspath(__file__)), junosTemplateLocation, 'baseTemplate.txt'), 'r') as f:
-            baseTemplate = f.read()
-            f.close()
-            return baseTemplate
+        baseTemplate = self.templateEnv.get_template('baseTemplate.txt')
+        config = baseTemplate.render()
+        return config
 
     def createInterfaces(self, device): 
         interfaceStanza = self.templateEnv.get_template('interface_stanza.txt')


### PR DESCRIPTION
Updated createBaseConfig function to make use of jinja2 template rendering in baseTemplate.txt. This allows for the inclusion of pre-existing modular config files. For example:

{% include 'BASE-SYSTEM' %}
{% include 'BASE-SNMP' %}
system {
    apply-groups BASE-SYSTEM;
}
snmp {
    apply-groups BASE-SYSTEM;
}