### PR TITLE
changing the default port to 20080, if for some reason ND fails to re…

### DIFF
--- a/jnpr/openclos/conf/openclos.yaml
+++ b/jnpr/openclos/conf/openclos.yaml
@@ -67,7 +67,7 @@ DOT :
 # REST will start at localhost
 httpServer :
     ipAddr : 0.0.0.0
-    port : 8888
+    port : 20080
 
 # Number of threads used to communicate with devices
 report :


### PR DESCRIPTION
…configure it, rest starts at port 8888, which conflicts with Space/ND services