### PR TITLE
fix for PR 1102406 VC links are not reflected in Connectivity check result 

### DIFF
--- a/jnpr/openclos/conf/cablingPlanTemplates/threeStageL2Report.json
+++ b/jnpr/openclos/conf/cablingPlanTemplates/threeStageL2Report.json
@@ -5,11 +5,11 @@
     {% endif %}{% endfor %}
   ],
   "links": [
-    {% for link in links %}    { "device1": "{{ link['device1'] }}", "port1": "{{ link['port1'] }}", "ip1":"{{ link['ip1'] }}", "device2": "{{ link['device2'] }}", "port2": "{{ link['port2'] }}", "ip2":"{{ link['ip2'] }}", "lldpStatus":"{{ link['lldpStatus'] }}"}{% if not loop.last %},
+    {% for link in links %}    {"linkType": "{{ link['linkType'] }}", "device1": "{{ link['device1'] }}", "port1": "{{ link['port1'] }}", "ip1":"{{ link['ip1'] }}", "device2": "{{ link['device2'] }}", "port2": "{{ link['port2'] }}", "ip2":"{{ link['ip2'] }}", "status":"{{ link['status'] }}"}{% if not loop.last %},
     {% endif %}{% endfor %}
   ]
 {% if additionalLinks | length > 0 %},  "additionalLinks": [
-    {% for link in additionalLinks %}    { "device1": "{{ link['device1'] }}", "port1": "{{ link['port1'] }}", "ip1":"{{ link['ip1'] }}", "device2": "{{ link['device2'] }}", "port2": "{{ link['port2'] }}", "ip2":"{{ link['ip2'] }}", "lldpStatus":"{{ link['lldpStatus'] }}"}{% if not loop.last %},
+    {% for link in additionalLinks %}    { "device1": "{{ link['device1'] }}", "port1": "{{ link['port1'] }}", "device2": "{{ link['device2'] }}", "port2": "{{ link['port2'] }}", "lldpStatus":"{{ link['lldpStatus'] }}"}{% if not loop.last %},
     {% endif %}{% endfor %}
   ]{% endif %}
 }

--- a/jnpr/openclos/conf/logging.yaml
+++ b/jnpr/openclos/conf/logging.yaml
@@ -1,7 +1,7 @@
 version: 1
 loggers:
     l3Clos :
-        level: DEBUG
+        level: INFO
         handlers: [console, file] 
     report : 
         level: INFO
@@ -10,13 +10,13 @@ loggers:
         level: INFO
         handlers: [console, file] 
     rest : 
-        level: DEBUG
+        level: INFO
         handlers: [console, file] 
     writer : 
         level: INFO
         handlers: [console, file] 
     devicePlugin : 
-        level: DEBUG
+        level: INFO
         handlers: [console, file] 
     trapd : 
         level: INFO

--- a/jnpr/openclos/conf/logging.yaml
+++ b/jnpr/openclos/conf/logging.yaml
@@ -1,7 +1,7 @@
 version: 1
 loggers:
     l3Clos :
-        level: INFO
+        level: DEBUG
         handlers: [console, file] 
     report : 
         level: INFO
@@ -10,13 +10,13 @@ loggers:
         level: INFO
         handlers: [console, file] 
     rest : 
-        level: INFO
+        level: DEBUG
         handlers: [console, file] 
     writer : 
         level: INFO
         handlers: [console, file] 
     devicePlugin : 
-        level: INFO
+        level: DEBUG
         handlers: [console, file] 
     trapd : 
         level: INFO

--- a/jnpr/openclos/dao.py
+++ b/jnpr/openclos/dao.py
@@ -145,7 +145,9 @@ class AbstractDao(SingletonBase):
         2. port name is uplink-* for device with known family 
         '''
         interconnectPorts = session.query(InterfaceDefinition).filter(InterfaceDefinition.device_id == device.id)\
-            .filter(InterfaceDefinition.peer != None).order_by(InterfaceDefinition.sequenceNum).all()
+            .filter(InterfaceDefinition.peer != None)\
+            .filter((InterfaceDefinition.role == 'uplink') | (InterfaceDefinition.role == 'downlink'))\
+            .order_by(InterfaceDefinition.sequenceNum).all()
 
         ports = []        
         for port in interconnectPorts:

--- a/jnpr/openclos/devicePlugin.py
+++ b/jnpr/openclos/devicePlugin.py
@@ -344,8 +344,8 @@ class L2DataCollector(DeviceDataCollectorNetconf):
         modifiedObjects = []
         goodSpines = []
         for ifd in ifds:
-            ifd.lldpStatus = 'good'
-            ifd.peer.lldpStatus = 'good'
+            ifd.status = 'good'
+            ifd.peer.status = 'good'
             goodSpines.append(ifd.peer)
             modifiedObjects.append(ifd)
             modifiedObjects.append(ifd.peer)
@@ -356,7 +356,7 @@ class L2DataCollector(DeviceDataCollectorNetconf):
     def updateIfdStatus(self, ifds, status):
         modifiedObjects = []
         for ifd in ifds:
-            ifd.lldpStatus = status
+            ifd.status = status
             modifiedObjects.append(ifd)
 
         self._dao.updateObjectsAndCommitNow(self._session, modifiedObjects)

--- a/jnpr/openclos/model.py
+++ b/jnpr/openclos/model.py
@@ -429,7 +429,7 @@ class InterfaceDefinition(Interface):
     id = Column(String(60), ForeignKey('interface.id' ), primary_key=True)
     role = Column(String(60))
     mtu = Column(Integer)
-    lldpStatus = Column(Enum('unknown', 'good', 'error'), default = 'unknown') 
+    status = Column(Enum('unknown', 'good', 'error'), default = 'unknown') 
         
     __mapper_args__ = {
         'polymorphic_identity':'physical',

--- a/jnpr/openclos/tests/unit/test_dao.py
+++ b/jnpr/openclos/tests/unit/test_dao.py
@@ -103,7 +103,7 @@ class TestDao(unittest.TestCase):
         with self.__dao.getReadWriteSession() as session:
             device = createDevice(session, "test")
             fakeSession = flexmock(session)
-            fakeSession.should_receive('query.filter.filter.order_by.all').\
+            fakeSession.should_receive('query.filter.filter.filter.order_by.all').\
                 and_return([InterfaceDefinition("et-0/1/0", None, 'uplink'), InterfaceDefinition("et-0/1/1", None, 'uplink'), 
                             InterfaceDefinition("uplink-2", None, 'uplink'), InterfaceDefinition("uplink-3", None, 'uplink')])
         

--- a/jnpr/openclos/tests/unit/test_devicePlugin.py
+++ b/jnpr/openclos/tests/unit/test_devicePlugin.py
@@ -209,9 +209,9 @@ class TestL2DataCollector(unittest.TestCase):
         
             dataCollector.updateBadIfdStatus([IFDs[4], IFDs[5]])
     
-            self.assertEqual('error', session.query(InterfaceDefinition).filter(InterfaceDefinition.id == IFDs[4].id).one().lldpStatus)
-            self.assertEqual('error', session.query(InterfaceDefinition).filter(InterfaceDefinition.id == IFDs[5].id).one().lldpStatus)
-            self.assertEqual('unknown', session.query(InterfaceDefinition).filter(InterfaceDefinition.id == IFDs[6].id).one().lldpStatus)
+            self.assertEqual('error', session.query(InterfaceDefinition).filter(InterfaceDefinition.id == IFDs[4].id).one().status)
+            self.assertEqual('error', session.query(InterfaceDefinition).filter(InterfaceDefinition.id == IFDs[5].id).one().status)
+            self.assertEqual('unknown', session.query(InterfaceDefinition).filter(InterfaceDefinition.id == IFDs[6].id).one().status)
 
     def testUpdateGoodIfdStatus(self):
         with self._dao.getReadSession() as session:
@@ -223,11 +223,11 @@ class TestL2DataCollector(unittest.TestCase):
         
             dataCollector.updateGoodIfdStatus([IFDs[4], IFDs[5]])
     
-            self.assertEqual('good', session.query(InterfaceDefinition).filter(InterfaceDefinition.id == IFDs[4].id).one().lldpStatus)
-            self.assertEqual('good', session.query(InterfaceDefinition).filter(InterfaceDefinition.id == IFDs[5].id).one().lldpStatus)
-            self.assertEqual('good', session.query(InterfaceDefinition).filter(InterfaceDefinition.id == IFDs[0].id).one().lldpStatus)
-            self.assertEqual('good', session.query(InterfaceDefinition).filter(InterfaceDefinition.id == IFDs[2].id).one().lldpStatus)
-            self.assertEqual('unknown', session.query(InterfaceDefinition).filter(InterfaceDefinition.id == IFDs[6].id).one().lldpStatus)
+            self.assertEqual('good', session.query(InterfaceDefinition).filter(InterfaceDefinition.id == IFDs[4].id).one().status)
+            self.assertEqual('good', session.query(InterfaceDefinition).filter(InterfaceDefinition.id == IFDs[5].id).one().status)
+            self.assertEqual('good', session.query(InterfaceDefinition).filter(InterfaceDefinition.id == IFDs[0].id).one().status)
+            self.assertEqual('good', session.query(InterfaceDefinition).filter(InterfaceDefinition.id == IFDs[2].id).one().status)
+            self.assertEqual('unknown', session.query(InterfaceDefinition).filter(InterfaceDefinition.id == IFDs[6].id).one().status)
             
             spine = IFDs[0].device
             self.assertEqual('deploy', spine.deployStatus)

--- a/jnpr/openclos/writer.py
+++ b/jnpr/openclos/writer.py
@@ -92,7 +92,7 @@ class CablingPlanWriter(WriterBase):
         devices = []
         links = []
         for device in self._pod.devices:
-            devices.append({'id': device.id, 'name': device.name, 'family': device.family, 'role': device.role, 'status': device.l2Status, 'reason': device.l2StatusReason, 'deployStatus': device.deployStatus})
+            devices.append({'id': device.id, 'name': device.name, 'family': device.family, 'role': device.role, 'deployStatus': device.deployStatus})
             if device.role == 'spine':
                 continue
             with self._dao.getReadSession() as session:
@@ -101,8 +101,8 @@ class CablingPlanWriter(WriterBase):
                     leafInterconnectIp = port.layerAboves[0].ipaddress #there is single IFL as layerAbove, so picking first one
                     spinePeerPort = port.peer
                     spineInterconnectIp = spinePeerPort.layerAboves[0].ipaddress #there is single IFL as layerAbove, so picking first one
-                    links.append({'device1': device.name, 'port1': port.name, 'ip1': leafInterconnectIp, 
-                                  'device2': spinePeerPort.device.name, 'port2': spinePeerPort.name, 'ip2': spineInterconnectIp, 'lldpStatus': port.lldpStatus})
+                    links.append({'linkType': 'interconnect', 'device1': device.name, 'port1': port.name, 'ip1': leafInterconnectIp, 
+                                  'device2': spinePeerPort.device.name, 'port2': spinePeerPort.name, 'ip2': spineInterconnectIp})
 
         return {'devices': devices, 'links': links}
     
@@ -263,8 +263,8 @@ class L2ReportWriter(WriterBase):
                         spinePeerPort = port.peer
                         spineInterconnectIp = spinePeerPort.layerAboves[0].ipaddress #there is single IFL as layerAbove, so picking first one
                         if spinePeerPort.device.deployStatus == 'deploy':
-                            links.append({'device1': device.name, 'port1': port.name, 'ip1': leafInterconnectIp, 
-                                          'device2': spinePeerPort.device.name, 'port2': spinePeerPort.name, 'ip2': spineInterconnectIp, 'lldpStatus': port.lldpStatus})
+                            links.append({'linkType': 'interconnect', 'device1': device.name, 'port1': port.name, 'ip1': leafInterconnectIp, 
+                                          'device2': spinePeerPort.device.name, 'port2': spinePeerPort.name, 'ip2': spineInterconnectIp, 'status': port.status})
 
         with self._dao.getReadSession() as session:
             # additional links
@@ -272,8 +272,8 @@ class L2ReportWriter(WriterBase):
             additionalLinks = session.query(AdditionalLink).all()
             if additionalLinks is not None:
                 for link in additionalLinks:
-                    additionalLinkList.append({'device1': link.device1, 'port1': link.port1, 'ip1': '', 
-                                               'device2': link.device2, 'port2': link.port2, 'ip2': '', 
+                    additionalLinkList.append({'device1': link.device1, 'port1': link.port1, 
+                                               'device2': link.device2, 'port2': link.port2, 
                                                'lldpStatus': link.lldpStatus})
 
         return {'devices': devices, 'links': links, 'additionalLinks': additionalLinkList}


### PR DESCRIPTION
tested by Praveen in a private build "root@cdbu-lnx04.englab.juniper.net:/root/openclos_rpms/yunli2004/devR2.5/OpenClos-ND-devR2.5-0bd1bfd.e1ba8df.noarch.rpm"

changes:
1. added linkType attribute in L2 report
2. change lldpStatus to status in L2 report and the model class because status could come from different data source depending on the linkType
3. minor restructure of _createLinks to allow OpenClosND to insert VC related code into the chain
4. fix the test cases
