### PR TITLE
PR 1173471 [Confidential] - create network:: system allows to assign …

### DIFF
--- a/jnpr/openclos/overlay/overlayModel.py
+++ b/jnpr/openclos/overlay/overlayModel.py
@@ -242,8 +242,8 @@ class OverlayNetwork(ManagedElement, Base):
     id = Column(String(60), primary_key=True)
     name = Column(String(255), nullable=False)
     description = Column(String(256))
-    vlanid = Column(Integer)
-    vnid = Column(Integer)
+    vlanid = Column(Integer, unique=True) # for current release, vlanid has to be globally unique
+    vnid = Column(Integer, unique=True) # for current release, vnid has to be globally unique
     pureL3Int = Column(Boolean)
     overlay_vrf_id = Column(String(60), ForeignKey('overlayVrf.id'), nullable=False)
     overlay_vrf = relationship("OverlayVrf", backref=backref('overlay_networks', order_by=name, cascade='all, delete, delete-orphan'))

--- a/jnpr/openclos/overlay/overlayRestRoutes.py
+++ b/jnpr/openclos/overlay/overlayRestRoutes.py
@@ -775,7 +775,7 @@ class OverlayRestRoutes():
         try:
             name = vrfDict['name']
             description = vrfDict.get('description')
-            routedVnid = vrfDict['routedVnid']
+            routedVnid = vrfDict.get('routedVnid')
             loopbackAddress = vrfDict.get('loopbackAddress')
             
             vrfObject = self.__dao.getObjectById(dbSession, OverlayVrf, vrfId)


### PR DESCRIPTION
…same resources to multiple tenants

make OverlayNetwork.vnid and vlanid globally unique for current release. In the future JUNOS release, vlanid might be the same for different tenants.

Reviewed by: yunli
