### PR TITLE
Use 1.17.0 version of paramiko

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 --index-url https://pypi.python.org/simple/
 
+paramiko==1.17.0
 netaddr
 sqlalchemy>=0.9.6
 pyyaml


### PR DESCRIPTION
We have to use 1.17.0 version of paramiko. Higher version of paramiko breaks the build
