### PR TITLE
PR 1171701 6-IL4: Device commit failure messages in db are too generi…

### DIFF
--- a/jnpr/openclos/deviceConnector.py
+++ b/jnpr/openclos/deviceConnector.py
@@ -301,8 +301,8 @@ class NetconfConnection(AbstractConnection):
             configurationUnit.lock()
             logger.debug('%s Locked config', self._debugContext)
         except LockError as exc:
-            logger.error('%s updateConfig failed, LockError: %s, %s, %s', self._debugContext, exc, exc.errs, exc.rpc_error)
-            raise DeviceRpcFailed('%s updateConfig failed' % (self._debugContext), exc)
+            logger.error('%s updateConfig failed, LockError: %s, %s', self._debugContext, exc.__repr__(), exc.rpc_error)
+            raise DeviceRpcFailed('%s updateConfig failed' % (self._debugContext), exc.__repr__())
 
         try:
             # make sure no changes are taken from CLI candidate config left over

--- a/jnpr/openclos/overlay/overlayCommit.py
+++ b/jnpr/openclos/overlay/overlayCommit.py
@@ -97,12 +97,12 @@ class OverlayCommitJob():
                 #logger.error("%s", exc)
                 #logger.error('StackTrace: %s', traceback.format_exc())
                 result = 'failure'
-                reason = exc.message
+                reason = exc.__repr__()
             except DeviceRpcFailed as exc:
                 #logger.error("%s", exc)
                 #logger.error('StackTrace: %s', traceback.format_exc())
                 result = 'failure'
-                reason = exc.message
+                reason = exc.__repr__()
             except Exception as exc:
                 #logger.error("%s", exc)
                 #logger.error('StackTrace: %s', traceback.format_exc())


### PR DESCRIPTION
…c, need to be show the actual error message
added missing code to handle LockError
