### PR TITLE
PR 1185269 Validation missing for vlan, it should be in the range 1-4094

### DIFF
--- a/jnpr/openclos/overlay/overlayModel.py
+++ b/jnpr/openclos/overlay/overlayModel.py
@@ -258,8 +258,6 @@ class OverlayNetwork(ManagedElement, Base):
         '''
         if vlanid < 1 or vlanid > 4096:
             raise ValueError("vlanid %s out of range (1-4096)" % vlanid)
-        if vnid < 1 or vnid > 4096:
-            raise ValueError("vnid %s out of range (1-4096)" % vnid)
 
         self.id = str(uuid.uuid4())
         self.name = name

--- a/jnpr/openclos/overlay/overlayRestRoutes.py
+++ b/jnpr/openclos/overlay/overlayRestRoutes.py
@@ -781,8 +781,6 @@ class OverlayRestRoutes():
             
         except bottle.HTTPError:
             raise 
-        except bottle.HTTPError:
-            raise 
         except KeyError as ex:
             logger.debug('Bad request: %s', ex.message)
             raise bottle.HTTPError(400, exception=InvalidRequest(ex.message))


### PR DESCRIPTION
revert the range check on vnid based on Sunil's feedback:
# 

Hi Yun,

Regarding VLAN, restriction 1-4094 is okay per fabric, but I think we should relax the number restrictions for vni-id as the number is huge and we just have to have unique VNI number in the network. 
So I feel there is no need to restrict VNI to 1-4094 as we don’t have to do 1:1 mapping with VLAN:VNI. 

root@test12321-leaf-0# set protocols evpn vni-options vni ?
Possible completions:
#   <id>                  (1..16777214)
