### PR TITLE
Delete conflicting stanza (unit 0) when creating overlayL2port.

### DIFF
--- a/jnpr/openclos/overlay/conf/junosTemplates/olAddInterface.txt
+++ b/jnpr/openclos/overlay/conf/junosTemplates/olAddInterface.txt
@@ -1,5 +1,7 @@
 interfaces {
     {{interfaceName}} {
+        delete:
+        unit 0;
         flexible-vlan-tagging;
         {% for network in networks %}unit {{network[0]}} {
             vlan-id {{network[0]}};


### PR DESCRIPTION
If we don't delete unit 0, commit will fail with following error:

interface-mode access is allowed only for untagged interfaces
