### PR TITLE
fix propertyLoader.mergeDict

### DIFF
--- a/jnpr/openclos/loader.py
+++ b/jnpr/openclos/loader.py
@@ -109,7 +109,7 @@ class PropertyLoader(object):
                 if type(v) is dict:
                     prop[k] = self.mergeDict(prop[k], v)
                 elif type(v) is list:
-                    prop[k] = list(set(prop[k]).union(v))
+                    prop[k] = [x for x in prop[k] if x not in v] + v
                 else:
                     prop[k] = v
             else:

--- a/jnpr/openclos/tests/unit/test_loader.py
+++ b/jnpr/openclos/tests/unit/test_loader.py
@@ -30,6 +30,17 @@ class TestPropertyLoader(unittest.TestCase):
         #print PropertyLoader.mergeDict(prop, override)
         self.assertDictEqual(merged, self.propertyLoader.mergeDict(prop, override))
 
+    def testMergetListNestedDict(self):
+        prop = {'plugin': [{'name': 'overlay', 'package': 'jnpr.openclos.overlay'}]}
+        override = {'plugin': [{'name': 'overlay', 'package': 'jnpr.openclos.overlay'}]}
+        merged = {'plugin': [{'name': 'overlay', 'package': 'jnpr.openclos.overlay'}]}
+        self.assertDictEqual(merged, self.propertyLoader.mergeDict(prop, override))
+
+        prop = {'plugin': [{'name': 'overlay', 'package': 'jnpr.openclos.overlay'}]}
+        override = {'plugin': [{'sample': 'fooo', 'bar': 'hoge'}]}
+        merged = {'plugin': [{'name': 'overlay', 'package': 'jnpr.openclos.overlay'}, {'sample': 'fooo', 'bar': 'hoge'}]}
+        self.assertDictEqual(merged, self.propertyLoader.mergeDict(prop, override))
+
     def testLoadProperty(self):
         self.propertyLoader = PropertyLoader('openclos.yaml', False)
         self.assertIsNot({}, self.propertyLoader._properties)


### PR DESCRIPTION
Hi, I found bug about merge process in loader.py.
dict can’t call set function in list.

```
>>> set([dict(a=1)])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: unhashable type: 'dict'
```

please check it.
