### PR TITLE
# Device port usage based on device family and topology

### DIFF
--- a/jnpr/openclos/conf/deviceFamily.yaml
+++ b/jnpr/openclos/conf/deviceFamily.yaml
@@ -5,6 +5,14 @@
 # When used as Spine in 5-Stage topology, ports are split between uplink and downlink 
 
 deviceFamily:
+    qfx5110-32q:
+        spine:
+          uplinkPorts: 'et-0/0/[16-23]'
+          downlinkPorts: 'et-0/0/[0-15]'
+    qfx5110-48s:
+        leaf:
+          uplinkPorts: 'et-0/0/[48-53]'
+          downlinkPorts: ['ge-0/0/[0-47]','xe-0/0/[0-47]']
     qfx5100-24q-2p:
         fabric:
             uplinkPorts: 
@@ -94,6 +102,10 @@ deviceFamily:
         spine:
             uplinkPorts:
             downlinkPorts: 'et-0/0/[0-71]'
+    qfx5110-32q:
+        spine:
+            uplinkPorts:
+            downlinkPorts: 'et-0/0/[0-31]'
     qfx10008:
         spine:
             # assuming 8 x ULC-36Q-12Q28 used

--- a/jnpr/openclos/tests/unit/test_loader.py
+++ b/jnpr/openclos/tests/unit/test_loader.py
@@ -193,7 +193,7 @@ class TestDeviceSku(unittest.TestCase):
 
     def testGetSupportedDeviceFamily(self):
         deviceFamilyList = self.deviceSku.getSupportedDeviceFamily()
-        self.assertEqual(13, len(deviceFamilyList))
+        self.assertEqual(15, len(deviceFamilyList))
 
     def testOverrideDeviceSku(self):
         overridePath = os.path.join(os.path.expanduser('~'), 'deviceFamily.yaml')

--- a/jnpr/openclos/tests/unit/test_underlayRestRoutes.py
+++ b/jnpr/openclos/tests/unit/test_underlayRestRoutes.py
@@ -290,7 +290,7 @@ class TestUnderlayRestRoutes(unittest.TestCase):
         self.assertEqual(200, response.status_int)
         self.assertTrue(response.json['OpenClosConf']['restServer'].has_key('port'))
         self.assertTrue(response.json['OpenClosConf']['snmpTrap']['openclos_trap_group'].has_key('port'))   
-        self.assertEquals(19, len(response.json['OpenClosConf']['supportedDevices']))
+        self.assertEquals(21, len(response.json['OpenClosConf']['supportedDevices']))
         
     def testdeletePod(self):
         with self._dao.getReadWriteSession() as session:


### PR DESCRIPTION
# qfx5100-24q-2p ports could have 32 ports with two four-port expansion modules
# When used as Fabric, all ports are downlink ports
# When used as Spine in 3-Stage topology, all ports are used as downlink
# When used as Spine in 5-Stage topology, ports are split between uplink and downlink

deviceFamily:
    qfx5110-32q:
        spine:
          uplinkPorts: 'et-0/0/[16-23]'
          downlinkPorts: 'et-0/0/[0-15]'
    qfx5110-48s:
        leaf:
          uplinkPorts: 'et-0/0/[48-53]'
          downlinkPorts: ['ge-0/0/[0-47]','xe-0/0/[0-47]']
    qfx5100-24q-2p:
        fabric:
            uplinkPorts:
            downlinkPorts: ['et-0/0/[0-23]', 'et-0/1/[0-3]', 'et-0/2/[0-3]']
        spine:
            uplinkPorts: ['et-0/0/[16-23]', 'et-0/1/[0-3]', 'et-0/2/[0-3]']
            downlinkPorts: 'et-0/0/[0-15]'
        leaf:
            uplinkPorts: 'et-0/0/[00-03]'
            downlinkPorts: ['et-0/0/[04-23]', 'et-0/1/[0-3]', 'et-0/2/[0-3]']
    qfx10002-36q:
        fabric:
            uplinkPorts:
            downlinkPorts: 'et-0/0/[0-35]'
        spine:
            uplinkPorts: 'et-0/0/[18-35]'
            downlinkPorts: 'et-0/0/[0-17]'
    qfx10002-72q:
        fabric:
            uplinkPorts:
            downlinkPorts: 'et-0/0/[0-71]'
        spine:
            uplinkPorts: 'et-0/0/[36-71]'
            downlinkPorts: 'et-0/0/[0-35]'
    qfx10008:
        fabric:
            uplinkPorts:
            downlinkPorts:
        spine:
            uplinkPorts:
            downlinkPorts:

    qfx5100-48s-6q:
        leaf:
            uplinkPorts: 'et-0/0/[48-53]'
            downlinkPorts: ['xe-0/0/[0-47]', 'ge-0/0/[0-47]']
    qfx5100-48t-6q:
        leaf:
            uplinkPorts: 'et-0/0/[48-53]'
            downlinkPorts: 'xe-0/0/[0-47]'
    qfx5100-96s-8q:
        leaf:
            uplinkPorts: 'et-0/0/[96-103]'
            downlinkPorts: ['xe-0/0/[0-95]', 'ge-0/0/[0-95]']
    qfx5200-32c-32q:
        spine:
            uplinkPorts:
            downlinkPorts: 'et-0/0/[00-31]'
        leaf:
            uplinkPorts: 'et-0/0/[00-07]'
            downlinkPorts: 'et-0/0/[08-31]'
    ex4300-24p:
        leaf:
            uplinkPorts: 'et-0/1/[0-3]'
            downlinkPorts: 'ge-0/0/[0-23]'
    ex4300-24t:
        leaf:
            uplinkPorts: 'et-0/1/[0-3]'
            downlinkPorts: 'ge-0/0/[0-23]'
    ex4300-32f:
        leaf:
            uplinkPorts: ['et-0/1/[0-1]', 'et-0/2/[0-1]']
            downlinkPorts: 'ge-0/0/[0-31]'
    ex4300-48p:
        leaf:
            uplinkPorts: 'et-0/1/[0-3]'
            downlinkPorts: 'ge-0/0/[0-47]'
    ex4300-48t:
        leaf:
            uplinkPorts: 'et-0/1/[0-3]'
            downlinkPorts: 'ge-0/0/[0-47]'

# additional customization of port allocation based on topology
3Stage:
    qfx5100-24q-2p:
        spine:
            uplinkPorts:
            downlinkPorts: ['et-0/0/[0-23]', 'et-0/1/[0-3]', 'et-0/2/[0-3]']
        leaf:
            uplinkPorts: 'et-0/0/[00-07]'
            downlinkPorts: ['et-0/0/[08-23]', 'et-0/1/[0-3]', 'et-0/2/[0-3]']
    qfx10002-36q:
        spine:
            uplinkPorts:
            downlinkPorts: 'et-0/0/[0-35]'
    qfx10002-72q:
        spine:
            uplinkPorts:
            downlinkPorts: 'et-0/0/[0-71]'
    qfx5110-32q:
        spine:
            uplinkPorts:
            downlinkPorts: 'et-0/0/[0-31]'
    qfx10008:
        spine:
            # assuming 8 x ULC-36Q-12Q28 used
            # if ULC-30Q28 is used, the port range would change to 'et-*/0/[0-29]'
            uplinkPorts:
            downlinkPorts: ['et-0/0/[0-35]', 'et-1/0/[0-35]', 'et-2/0/[0-35]', 'et-3/0/[0-35]', 'et-4/0/[0-35]', 'et-5/0/[0-35]', 'et-6/0/[0-35]', 'et-7/0/[0-35]']

5Stage:

lineCard:
    ULC-30Q28:
        uplinkPorts:
        downlinkPorts: 'et-0/0/[0-29]'
    ULC-36Q-12Q28:
        uplinkPorts:
        downlinkPorts: 'et-0/0/[0-35]'
    ULC-60S-6Q:
        uplinkPorts: 'et-0/0/[0-59]'
        downlinkPorts: 'et-0/0/[60-65]'